### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+<!-- markdownlint-disable-file MD024 -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog], and this project adheres
+to [Semantic Versioning].
+
+## [0.1.0] - 2024-10-27
+
+Initial release of the `doco` and `doco-derive` crates
+
+[0.1.0]: https://github.com/otterbuild/doco/releases/tag/v0.1.0
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/
+[semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "doco"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "doco-derive"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["examples"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 
 description = "A framework and runner for end-to-end tests for web applications"

--- a/examples/axum-postgres/Cargo.lock
+++ b/examples/axum-postgres/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "axum-postgres"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "axum",
  "doco",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "doco"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "doco-derive",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "doco-derive"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "quote",
  "syn",

--- a/examples/axum-postgres/Cargo.toml
+++ b/examples/axum-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-postgres"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 
 [[test]]

--- a/examples/leptos/Cargo.lock
+++ b/examples/leptos/Cargo.lock
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "doco"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "doco-derive",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "doco-derive"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "quote",
  "syn 2.0.77",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "leptos-ssr"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/examples/leptos/Cargo.toml
+++ b/examples/leptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-ssr"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Version 0.1.0 is the first public release of Doco, featuring a proof-of-concept for the `doco::main` and `doco::test` macros.