### PR TITLE
Fix publishing the crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Publish crate
-        run: cargo publish -v --all-features
+      - name: Publish doco-derive
+        run: cargo publish -v --all-features -p doco-derive
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
+      - name: Publish doco
+        run: cargo publish -v --all-features -p doco
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 description = "A framework and runner for end-to-end tests for web applications"
 homepage = "https://github.com/otterbuild/doco"
 repository = "https://github.com/otterbuild/doco.git"
+readme = "README.md"
 
 [workspace.metadata.bin]
 leptosfmt = { version = "0.1.30" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 description = "A framework and runner for end-to-end tests for web applications"
 homepage = "https://github.com/otterbuild/doco"

--- a/crates/doco-derive/Cargo.toml
+++ b/crates/doco-derive/Cargo.toml
@@ -8,6 +8,8 @@ description.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+readme = "../../README.md"
+
 [lib]
 proc-macro = true
 

--- a/crates/doco-derive/Cargo.toml
+++ b/crates/doco-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "doco-derive"
 
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 description.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/doco/Cargo.toml
+++ b/crates/doco/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 description.workspace = true
 repository.workspace = true
 
+readme = "../../README.md"
+
 [dependencies]
 anyhow = "1.0.86"
 doco-derive = { path = "../doco-derive", version = "0.1.0" }

--- a/crates/doco/Cargo.toml
+++ b/crates/doco/Cargo.toml
@@ -3,6 +3,7 @@ name = "doco"
 
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 description.workspace = true
 repository.workspace = true
 

--- a/crates/doco/Cargo.toml
+++ b/crates/doco/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.86"
-doco-derive = { path = "../doco-derive" }
+doco-derive = { path = "../doco-derive", version = "0.1.0" }
 fantoccini = "0.21.2"
 getset = "0.1.2"
 inventory = "0.3.15"


### PR DESCRIPTION
A few different things failed when trying to publish the crates for the first time using the GitHub Actions workflow. For one, crates.io requires crates to have a valid `license` specified in their `Cargo.toml`. And Cargo does not support running `cargo publish` on a workspace without specifying a specific crate, and it requires a version for the internal `doco-derive` dependency.

Additionally, we also linked the README into the different crates to improve the presentation of the crates on crates.io.