### PR TITLE
Disable test coverage for proc macro crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,7 @@ jobs:
           cargo tarpaulin \
             --all-features \
             --engine llvm \
+            --exclude doco-derive \
             --out Xml \
             --skip-clean \
             --timeout 120 \


### PR DESCRIPTION
The combination of Rust 1.83.0, cargo-tarpaulin, and proc macro crates is currently broken. We are excluding the proc macro crate from test coverage to unblock the upgradae to 1.83.0.