### PR TITLE
Create Earthly targets for axum example

### DIFF
--- a/.github/workflows/axum.yml
+++ b/.github/workflows/axum.yml
@@ -8,10 +8,6 @@ name: Example / axum
   pull_request:
   workflow_dispatch:
 
-env:
-  CARGO_INCREMENTAL: 0
-  CARGO_PROFILE_TEST_DEBUG: 0
-
 jobs:
   detect-changes:
     name: Detect changes
@@ -39,30 +35,46 @@ jobs:
             echo "$file"
           done
 
+  format:
+    name: Check Rust style
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    needs: detect-changes
+    if: needs.detect-changes.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
+
+      - name: Run check with Earthly
+        env:
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --ci --push --remote-cache=ghcr.io/otterbuild/doco-earthly-cache:example-axum-format +example-axum-format
+
   lint:
     name: Lint Rust code
     runs-on: ubuntu-latest
 
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache build artifacts
-        uses: swatinem/rust-cache@v2.7.7
-        with:
-          prefix-key: axum-1.84.1
-          workspaces: examples/axum-postgres -> target
-
-      - name: Run Clippy
-        working-directory: examples/axum-postgres
-        run: cargo clippy --all-features --all-targets -- -D warnings
-
-  style:
-    name: Check Rust style
-    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     needs: detect-changes
     if: needs.detect-changes.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
@@ -71,20 +83,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache build artifacts
-        uses: swatinem/rust-cache@v2.7.7
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          prefix-key: axum-1.84.1
-          workspaces: examples/axum-postgres -> target
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run rustfmt
-        working-directory: examples/axum-postgres
-        run: cargo fmt --check
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
+
+      - name: Run check with Earthly
+        env:
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --ci --push --remote-cache=ghcr.io/otterbuild/doco-earthly-cache:example-axum-lint +example-axum-lint
 
   test:
     name: Run Rust tests
     runs-on: ubuntu-latest
 
+    permissions:
+      packages: write
+      contents: read
+
     needs: detect-changes
     if: needs.detect-changes.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
 
@@ -92,25 +116,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache build artifacts
-        uses: swatinem/rust-cache@v2.7.7
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          prefix-key: axum-1.84.1
-          workspaces: examples/axum-postgres -> target
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker image for axum app
-        uses: docker/build-push-action@v6
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
         with:
-          context: .
-          file: examples/axum-postgres/Dockerfile
-          load: true
-          tags: doco:axum-postgres
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
 
-      - name: Run tests
-        working-directory: examples/axum-postgres
-        run: cargo test --all-features --all-targets
+      - name: Run check with Earthly
+        env:
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --allow-privileged --push --remote-cache=ghcr.io/otterbuild/doco-earthly-cache:example-axum-test --strict +example-axum-test

--- a/.github/workflows/leptos.yml
+++ b/.github/workflows/leptos.yml
@@ -25,7 +25,7 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: |
-            .github/workflows/axum.yml
+            .github/workflows/leptos.yml
             crates/**/*
             examples/leptos/**/*
 

--- a/Earthfile
+++ b/Earthfile
@@ -64,6 +64,38 @@ rust-tarpaulin-container:
     # Cache the container
     SAVE IMAGE --cache-hint
 
+example-axum-container:
+    FROM +rust-sources
+
+    # Copy the example
+    COPY --keep-ts --dir examples/axum-postgres examples/axum-postgres
+
+    # Change the working directory
+    WORKDIR examples/axum-postgres
+
+example-axum-docker:
+    FROM DOCKERFILE -f examples/axum-postgres/Dockerfile .
+
+example-axum-format:
+    FROM +example-axum-container
+
+    # Check the code formatting
+    DO rust+CARGO --args="fmt --all --check"
+
+example-axum-lint:
+    FROM +example-axum-container
+
+    # Check the code for linting errors
+    DO rust+CARGO --args="clippy --all-targets --all-features -- -D warnings"
+
+example-axum-test:
+    FROM +example-axum-container
+
+    # Run the tests
+    WITH DOCKER --load doco:axum-postgres=+example-axum-docker
+        RUN cargo test --all-features --all-targets --locked
+    END
+
 example-leptos-container:
     FROM +rust-sources
 


### PR DESCRIPTION
To make it easier to develop and run the axum example locally, targets have been created to format, lint, and test the example using Earthly.