### PR TITLE
Update Rust version in Earthfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>otterbuild/renovate-config"]
+  "extends": ["local>otterbuild/renovate-config"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["Earthfile"],
+      "matchStrings": ["rust:(?<currentValue>.*?)(-[\\w]+)?"],
+      "depNameTemplate": "rust",
+      "datasourceTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
A custom regex manager has been added to the Renovate configuration. The manager updates the Rust version in the `Earthfile`, ensuring that the same version is used in loal development and the CI/CD pipeline.